### PR TITLE
Fix resume recovery for zero-offset chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]
@@ -182,9 +184,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/downloaderx/__init__.py
+++ b/downloaderx/__init__.py
@@ -1,2 +1,6 @@
-from .invoker import download
-from .type import *
+from .invoker import download as download
+from .type import FileDownloadError as FileDownloadError
+from .type import RetryError as RetryError
+from .type import Task as Task
+from .type import TaskError as TaskError
+from .type import TooManyRetriesError as TooManyRetriesError

--- a/downloaderx/file/__init__.py
+++ b/downloaderx/file/__init__.py
@@ -1,2 +1,4 @@
-from .errors import *
-from .file_downloader import FileDownloader
+from .errors import CanRetryError as CanRetryError
+from .errors import InterruptionError as InterruptionError
+from .errors import RangeDownloadFailedError as RangeDownloadFailedError
+from .file_downloader import FileDownloader as FileDownloader

--- a/downloaderx/file/range_downloader.py
+++ b/downloaderx/file/range_downloader.py
@@ -107,23 +107,25 @@ class RangeDownloader:
     def _search_offsets(self, length: int):
         wanna_tail = f"{self._file_path.suffix[1:]}{DOWNLOADING_SUFFIX}"
         file_stem = glob.escape(self._file_path.stem)  # maybe include "*" signs
+        first_chunk_name = chunk_name(self._file_path, 0)
 
         for matched_path in self._file_path.parent.glob(f"{file_stem}*"):
-            matched_tail = matched_path.name[len(self._file_path.stem) :]
-            if matched_tail == DOWNLOADING_SUFFIX:
+            if matched_path.name == first_chunk_name:
                 yield 0
-            else:
-                parts = matched_tail.split(".", maxsplit=2)
-                if len(parts) == 3 and parts[0] == "":
-                    _, str_offset, tail = parts
-                    if tail == wanna_tail:
-                        offset: int = -1
-                        try:
-                            offset = int(str_offset)
-                        except ValueError:
-                            pass
-                        if 0 < offset < length:
-                            yield offset
+                continue
+
+            matched_tail = matched_path.name[len(self._file_path.stem) :]
+            parts = matched_tail.split(".", maxsplit=2)
+            if len(parts) == 3 and parts[0] == "":
+                _, str_offset, tail = parts
+                if tail == wanna_tail:
+                    offset: int = -1
+                    try:
+                        offset = int(str_offset)
+                    except ValueError:
+                        pass
+                    if 0 < offset < length:
+                        yield offset
 
     @property
     def serial(self) -> Serial:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "downloaderx"
-version = "0.1.9"
+version = "0.1.10"
 description = "Multi-threaded, resumable file downloader for Python"
 authors = [
     {name = "Tao Zeyu", email = "i@taozeyu.com"}

--- a/tests/test_file_downloader.py
+++ b/tests/test_file_downloader.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from threading import Thread
 from typing import Callable
 
@@ -15,6 +16,8 @@ from downloaderx.file import (
     InterruptionError,
     RangeDownloadFailedError,
 )
+from downloaderx.file.common import chunk_name
+from downloaderx.file.range_downloader import RangeDownloader
 from tests.start_flask import PORT
 
 _TEMP_PATH = Path(__file__).parent / "temp" / "file_downloader"
@@ -339,3 +342,38 @@ class TestContentLengthFallback(unittest.TestCase):
             _sha256(download_file),
             _sha256(raw_file),
         )
+
+
+class TestRangeDownloaderResumeOffsets(unittest.TestCase):
+    def test_search_offsets_recovers_zero_chunk_for_regular_suffix(self):
+        offsets = self._search_offsets_for_existing_chunks(
+            file_name="mirai.jpg",
+            existing_offsets=[0, 1234],
+            content_length=10_000,
+        )
+
+        self.assertEqual(offsets, [0, 1234])
+
+    def test_search_offsets_recovers_zero_chunk_for_compressed_suffix(self):
+        offsets = self._search_offsets_for_existing_chunks(
+            file_name="latest-all-json.bz2",
+            existing_offsets=[0, 23_173_786_269, 46_347_572_538],
+            content_length=100_000_000_000,
+        )
+
+        self.assertEqual(offsets, [0, 23_173_786_269, 46_347_572_538])
+
+    def _search_offsets_for_existing_chunks(
+        self,
+        file_name: str,
+        existing_offsets: list[int],
+        content_length: int,
+    ) -> list[int]:
+        with TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / file_name
+            for offset in existing_offsets:
+                (file_path.parent / chunk_name(file_path, offset)).write_bytes(b"x")
+
+            range_downloader = RangeDownloader.__new__(RangeDownloader)
+            range_downloader._file_path = file_path  # pylint: disable=protected-access
+            return sorted(range_downloader._search_offsets(content_length))  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary
- Fix resume scanning so offset-0 chunks are recognized using the actual chunk_name() output
- Add regression coverage for regular suffix and .bz2 resume chunk names
- Bump package version to 0.1.10 for release prep
- Keep .gitignore cleanup in this branch
- Make public re-exports explicit so full ruff checks pass

Fixes #17

## Validation
- poetry check
- poetry run ruff check .
- poetry run python -m unittest discover -s tests
- poetry build --output "/var/folders/g0/wsv4gwcn7fx5v_hbs824cng00000gn/T/tmp.xMVtSKv1JK"